### PR TITLE
Invoke poetry with full location

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ build:
     post_create_environment:
       - curl -sSL https://install.python-poetry.org | python3 -
     post_install:
-      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH /home/docs/.local/bin/poetry install
 
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
`poetry` is not in the path. Invoking it directly

![image](https://github.com/Junglescout/junglescout-python-client/assets/1870760/0df98cbc-7bb5-403b-97e0-26d78f968db6)
