### PR TITLE
fix: Add optional typing on SalesEstimatesAttributes

### DIFF
--- a/src/junglescout/models/responses/sales_estimates.py
+++ b/src/junglescout/models/responses/sales_estimates.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 
 from pydantic import BaseModel, Field, field_serializer
 
@@ -21,16 +21,20 @@ class SalesEstimateData(BaseModel):
 class SalesEstimateAttributes(BaseModel):
     """The attributes of the sales estimate."""
 
-    asin: str = Field(
-        default=..., description="The ASIN (Amazon Standard Identification Number) associated with the sales estimate."
+    asin: Optional[str] = Field(
+        default=None, description="The ASIN (Amazon Standard Identification Number) associated with the sales estimate."
     )
-    is_parent: bool = Field(default=..., description="A boolean indicating whether the ASIN is a parent ASIN.")
-    is_variant: bool = Field(default=..., description="A boolean indicating whether the ASIN is a variant.")
-    is_standalone: bool = Field(
-        default=..., description="A boolean indicating whether the ASIN is a standalone product."
+    is_parent: Optional[bool] = Field(
+        default=None, description="A boolean indicating whether the ASIN is a parent ASIN."
     )
-    parent_asin: str = Field(default=..., description="The parent ASIN associated with the sales estimate.")
-    variants: List[str] = Field(default=..., description="The variant ASINs associated with the sales estimate.")
+    is_variant: Optional[bool] = Field(default=None, description="A boolean indicating whether the ASIN is a variant.")
+    is_standalone: Optional[bool] = Field(
+        default=None, description="A boolean indicating whether the ASIN is a standalone product."
+    )
+    parent_asin: Optional[str] = Field(default=None, description="The parent ASIN associated with the sales estimate.")
+    variants: Optional[List[str]] = Field(
+        default=None, description="The variant ASINs associated with the sales estimate."
+    )
     data: List[SalesEstimateData] = Field(default=..., description="The sales estimate data.")
 
 


### PR DESCRIPTION
### Description:

Changes typing on the `SalesEstimatesAttributes` to optional on the Pydantic model.

Fixes cases like this:
```
Traceback (most recent call last):
[...]
pydantic_core._pydantic_core.ValidationError: 1 validation error for APIResponse[List[SalesEstimates]] data.0.attributes.parent_asin Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
```