### PR TITLE
fix: Adds extra test and default array value

### DIFF
--- a/src/junglescout/client.py
+++ b/src/junglescout/client.py
@@ -333,6 +333,9 @@ class Client:
         if seller_types is None:
             seller_types = [SellerTypes.AMZ, SellerTypes.FBA, SellerTypes.FBM]
 
+        if exclude_keywords is None:
+            exclude_keywords = []
+
         marketplace = self._resolve_marketplace(marketplace)
 
         params = ProductDatabaseParams(


### PR DESCRIPTION
## Issues:

Closes #76.

## Description:

The `exclude_keywords` param on the `product_database_query` is optional for the end user, but it is required by the API. This PRs adds a `[]` default array value when the value is not declared by the end user as it's the expected behavior.

