### PR TITLE
fix: Adds optional on datetime serializer functions

### DIFF
--- a/src/junglescout/models/responses/serializer_helpers.py
+++ b/src/junglescout/models/responses/serializer_helpers.py
@@ -1,11 +1,12 @@
 from datetime import datetime
+from typing import Optional
 
 
-def serialize_datetime(dt: datetime) -> str:
+def serialize_datetime(dt: Optional[datetime]) -> str:
     """Serialize a datetime object to a datetime string."""
-    return dt.strftime("%Y-%m-%dT%H:%M:%S.%f")
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%f") if dt else None
 
 
-def serialize_date(dt: datetime) -> str:
+def serialize_date(dt: Optional[datetime]) -> str:
     """Serialize a datetime object to a date string."""
-    return dt.strftime("%Y-%m-%d")
+    return dt.strftime("%Y-%m-%d") if dt else None

--- a/src/junglescout/models/responses/serializer_helpers.py
+++ b/src/junglescout/models/responses/serializer_helpers.py
@@ -2,11 +2,11 @@ from datetime import datetime
 from typing import Optional
 
 
-def serialize_datetime(dt: Optional[datetime]) -> str:
+def serialize_datetime(dt: Optional[datetime]) -> Optional[str]:
     """Serialize a datetime object to a datetime string."""
     return dt.strftime("%Y-%m-%dT%H:%M:%S.%f") if dt else None
 
 
-def serialize_date(dt: Optional[datetime]) -> str:
+def serialize_date(dt: Optional[datetime]) -> Optional[str]:
     """Serialize a datetime object to a date string."""
     return dt.strftime("%Y-%m-%d") if dt else None


### PR DESCRIPTION
## Issues:

No related issue.

## Description:

Adds `Optional[datetime]` when serializing `updated_at` and `created_at` fields, as they can sometimes, be null.