### PR TITLE
chore: Add Rate Limit section to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ See the [Jungle Scout API Documentation](https://developer.junglescout.com) and 
 [Jungle Scout Postman Collection](https://postman.junglescout.com) for more information about
 the Jungle Scout API.
 
+## Rate Limits
+
+The current API request limit per minute is 300, and our burst limit per second is 15.
+
 ## Installation
 
 ```bash

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -44,6 +44,11 @@ Analyzing the Response
 
 Responses from the Jungle Scout API are returned as instances of...
 
+Rate Limiting
+=============
+
+The Jungle Scout API enforces rate limits as following: 300 requests per minute or 15 requests per second. If you exceed the rate limit, you will receive a 429 status code in response to your request.
+
 What's Next?
 ============
 


### PR DESCRIPTION
## Description:

Add a section about rate limiting on the readme and read the docs documentation.

Relates to #85.