### PR TITLE
chore: Add missing asyncio decorators to tests and use httpx content param

### DIFF
--- a/src/junglescout/client_async.py
+++ b/src/junglescout/client_async.py
@@ -204,7 +204,9 @@ class ClientAsync(Client[AsyncSession]):
         )
         request_instance = KeywordsByKeywordRequest.from_args(args, self.session)
         response = await self.session.request(
-            request_instance.method.value, request_instance.url, data=json.dumps(request_instance.payload_serialized)
+            request_instance.method.value,
+            request_instance.url,
+            content=json.dumps(request_instance.payload_serialized).encode("utf-8"),
         )
         if response.is_success:
             return APIResponse[List[KeywordByKeyword]].model_validate(response.json())
@@ -365,7 +367,9 @@ class ClientAsync(Client[AsyncSession]):
         )
         request_instance = ProductDatabaseRequest.from_args(args, self.session)
         response = await self.session.request(
-            request_instance.method.value, request_instance.url, data=json.dumps(request_instance.payload_serialized)
+            request_instance.method.value,
+            request_instance.url,
+            content=json.dumps(request_instance.payload_serialized).encode("utf-8"),
         )
         if response.is_success:
             return APIResponse[List[ProductDatabase]].model_validate(response.json())

--- a/src/junglescout/client_sync.py
+++ b/src/junglescout/client_sync.py
@@ -199,7 +199,9 @@ class ClientSync(Client[SyncSession]):
         )
         request_instance = KeywordsByKeywordRequest.from_args(args, self.session)
         response = self.session.request(
-            request_instance.method.value, request_instance.url, data=json.dumps(request_instance.payload_serialized)
+            request_instance.method.value,
+            request_instance.url,
+            content=json.dumps(request_instance.payload_serialized).encode("utf-8"),
         )
         if response.is_success:
             return APIResponse[List[KeywordByKeyword]].model_validate(response.json())
@@ -352,7 +354,9 @@ class ClientSync(Client[SyncSession]):
         )
         request_instance = ProductDatabaseRequest.from_args(args, self.session)
         response = self.session.request(
-            request_instance.method.value, request_instance.url, data=json.dumps(request_instance.payload_serialized)
+            request_instance.method.value,
+            request_instance.url,
+            content=json.dumps(request_instance.payload_serialized).encode("utf-8"),
         )
         if response.is_success:
             return APIResponse[List[ProductDatabase]].model_validate(response.json())

--- a/tests/integration/client_async/test_keywords_by_asin.py
+++ b/tests/integration/client_async/test_keywords_by_asin.py
@@ -20,6 +20,7 @@ async def test_two_keywords_by_asin(api_keys):
 
 
 @pytest.mark.integration()
+@pytest.mark.asyncio()
 async def test_two_keywords_by_asin_using_context_manager(api_keys):
     filter_options = FilterOptions(min_monthly_search_volume_exact=150)
     async with ClientAsync(**api_keys, marketplace=Marketplace.US) as client:
@@ -33,6 +34,7 @@ async def test_two_keywords_by_asin_using_context_manager(api_keys):
 
 
 @pytest.mark.integration()
+@pytest.mark.asyncio()
 async def test_single_asin_with_sparse_data(api_keys):
     client = ClientAsync(**api_keys, marketplace=Marketplace.US)
     filter_options = FilterOptions(min_monthly_search_volume_exact=150)


### PR DESCRIPTION
# Description

- Several tests were being skipped because they were missing the `@pytest.mark.asyncio` decorator
- Using `content` rather than `data` when making requests with `httpx` to avoid the `DeprecationWarning`
