### PR TITLE
chore: Simplify PyPI check in semantic-release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.12
-          cache: 'poetry'
+          cache: "poetry"
       - name: Install dependencies
         run: poetry install
       - name: Create .env file
@@ -36,14 +36,15 @@ jobs:
           poetry run semantic-release version --no-changelog
 
           NEXT_VERSION=$(poetry run semantic-release --noop version --print-tag)
-          echo "Next version: ${NEXT_VERSION}"
+          NEXT_VERSION_NO_PREFIX=${NEXT_VERSION#v}
+          echo "Next version: ${NEXT_VERSION_NO_PREFIX}"
 
-          if curl -s https://pypi.org/pypi/junglescout-client/json | jq -r '.releases | keys[]' | grep -q "^${NEXT_VERSION}$"; then
+          if curl -s https://pypi.org/pypi/junglescout-client/json | jq -r '.releases | keys[]' | grep -q "^${NEXT_VERSION_NO_PREFIX}$"; then
             echo "SHOULD_PUBLISH=0" >> $GITHUB_ENV
-            echo "Version ${NEXT_VERSION} already exists on PyPI"
+            echo "Version ${NEXT_VERSION_NO_PREFIX} already exists on PyPI"
           else
             echo "SHOULD_PUBLISH=1" >> $GITHUB_ENV
-            echo "New version ${NEXT_VERSION} does not exist on PyPI"
+            echo "New version ${NEXT_VERSION_NO_PREFIX} does not exist on PyPI"
           fi
       - name: Publish to PyPI
         if: env.SHOULD_PUBLISH == '1'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,4 +50,6 @@ jobs:
         if: env.SHOULD_PUBLISH == '1'
         env:
           POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
-        run: poetry publish
+        run: |
+          poetry build --clean
+          poetry publish --no-interaction


### PR DESCRIPTION
# Description

We ran into an issue with the latest release, where the release workflow failed, and re-running it after fixing the release didn't upload a new release to PyPI. This PR aims to make retrying the release workflow works as expected, when it comes to uploading new releases to PyPI.